### PR TITLE
Typo fix - Part 7 database queries

### DIFF
--- a/crm1_v7_database_queries/accounts/queryDemos.py
+++ b/crm1_v7_database_queries/accounts/queryDemos.py
@@ -59,7 +59,7 @@ class ParentModel(models.Model):
 	name = models.CharField(max_length=200, null=True)
 
 class ChildModel(models.Model):
-	parent = models.ForeignKey(Customer)
+	parent = models.ForeignKey(ParentModel)
 	name = models.CharField(max_length=200, null=True)
 
 parent = ParentModel.objects.first()


### PR DESCRIPTION
Replaced 'Customer' at 'parent = models.ForeignKey(Customer)' with 'ParentModel'.